### PR TITLE
Add day filter and daily totals

### DIFF
--- a/src/app/(frontend)/(main)/admin/attendance-requests/page.js
+++ b/src/app/(frontend)/(main)/admin/attendance-requests/page.js
@@ -20,6 +20,7 @@ export default function AttendanceRequestsPage() {
   const [filters, setFilters] = useState({
     year: new Date().getFullYear(),
     month: new Date().getMonth() + 1,
+    day: new Date().getDate(),
     workerId: null,
     groupId: null,
     approvalStatus: "PENDING"
@@ -67,6 +68,7 @@ export default function AttendanceRequestsPage() {
     const processedFilters = {
       year: newFilters.year || new Date().getFullYear(),
       month: newFilters.month || new Date().getMonth() + 1,
+      day: newFilters.day || new Date().getDate(),
       workerId: newFilters.workerId || null,
       groupId: newFilters.groupId || null,
       approvalStatus: "PENDING"

--- a/src/containers/attendance-requests/filterRow.js
+++ b/src/containers/attendance-requests/filterRow.js
@@ -30,6 +30,14 @@ const getMonthOptions = () => {
   }));
 };
 
+// Helper to generate day options (1-31)
+const getDayOptions = () => {
+  return Array.from({ length: 31 }, (_, i) => ({
+    value: i + 1,
+    label: String(i + 1),
+  }));
+};
+
 // Helper to generate year options (current year and 2 previous years)
 const getYearOptions = () => {
   const currentYear = new Date().getFullYear();
@@ -127,6 +135,9 @@ export default function AttendanceRequestsFilter({
           value: new Date().getMonth() + 1,
           label: getMonthOptions()[new Date().getMonth()]?.label,
         },
+    day: initialFilters?.day
+      ? { value: initialFilters.day, label: String(initialFilters.day) }
+      : { value: new Date().getDate(), label: String(new Date().getDate()) },
     workerId: initialFilters?.workerId || null,
     groupId: initialFilters?.groupId || null,
   });
@@ -205,12 +216,14 @@ export default function AttendanceRequestsFilter({
   const handleReset = () => {
     const currentYear = new Date().getFullYear();
     const currentMonth = new Date().getMonth() + 1;
+    const currentDay = new Date().getDate();
     const resetFilters = {
       year: { value: currentYear, label: String(currentYear) },
       month: {
         value: currentMonth,
         label: getMonthOptions()[currentMonth - 1]?.label,
       },
+      day: { value: currentDay, label: String(currentDay) },
       workerId: null,
       groupId: null,
     };
@@ -218,6 +231,7 @@ export default function AttendanceRequestsFilter({
     onFilterChange({
       year: currentYear,
       month: currentMonth,
+      day: currentDay,
       workerId: null,
       groupId: null,
       approvalStatus: "PENDING",
@@ -229,6 +243,7 @@ export default function AttendanceRequestsFilter({
     const formattedFilters = {
       year: filters.year.value,
       month: filters.month.value,
+      day: filters.day.value,
       workerId: filters.workerId?.value,
       groupId: filters.groupId?.value,
       approvalStatus: "PENDING",
@@ -258,6 +273,23 @@ export default function AttendanceRequestsFilter({
               value={filters.month}
               onChange={(option) => handleFilterChange(option, "month")}
               placeholder="בחר חודש"
+              components={{
+                IndicatorSeparator: () => null,
+              }}
+              styles={selectStyle}
+              menuPortalTarget={document.body}
+              menuPosition={"fixed"}
+              isRtl={true}
+            />
+          </div>
+
+          <div className={styles.filterItem}>
+            <label className={styles.label}>יום</label>
+            <ReactSelect
+              options={getDayOptions()}
+              value={filters.day}
+              onChange={(option) => handleFilterChange(option, "day")}
+              placeholder="בחר יום"
               components={{
                 IndicatorSeparator: () => null,
               }}

--- a/src/containers/attendance-requests/table.js
+++ b/src/containers/attendance-requests/table.js
@@ -99,6 +99,11 @@ export default function AttendanceRequestsTable({
   // Create a map to track container value cells
   const containerCellsRef = useRef({});
 
+  // Calculate total containers for summary row
+  const totalContainers = requests.reduce((sum, r) => {
+    return sum + (r.totalContainersFilled || 0);
+  }, 0);
+
   // Force re-render the entire table
   const forceRefresh = () => {
     setRefreshKey((prevKey) => prevKey + 1);
@@ -434,6 +439,13 @@ export default function AttendanceRequestsTable({
               </tr>
             ))}
           </tbody>
+          <tfoot>
+            <tr className={styles.totalRow}>
+              <td colSpan={6}>סך הכל קונטיינרים</td>
+              <td>{totalContainers}</td>
+              <td></td>
+            </tr>
+          </tfoot>
         </table>
       </div>
 

--- a/src/styles/screens/attendance-requests.module.scss
+++ b/src/styles/screens/attendance-requests.module.scss
@@ -258,10 +258,15 @@ $gray-500: #6b7280;
       &:hover {
         background-color: $gray-50;
       }
-      
+
       &:last-child td {
         border-bottom: none;
       }
+    }
+
+    tfoot td {
+      font-weight: 600;
+      background-color: $gray-50;
     }
   }
 }


### PR DESCRIPTION
## Summary
- support day filter in `getAttendanceRequests`
- allow selecting day in attendance request filters
- keep day in page state and handle day when filtering
- show total containers row in pending attendance table
- style table footer

## Testing
- `npm run lint` *(fails: Cannot serialize key "parse" in parser)*