### PR TITLE
Add daily filter and total stats for pending attendance

### DIFF
--- a/src/app/(frontend)/(main)/admin/attendance-requests/page.js
+++ b/src/app/(frontend)/(main)/admin/attendance-requests/page.js
@@ -305,6 +305,10 @@ export default function AttendanceRequestsPage() {
   
   // Calculate pending requests count
   const pendingRequestsCount = attendanceRequests.length || 0;
+  const totalContainers = attendanceRequests.reduce(
+    (sum, r) => sum + (r.totalContainersFilled || 0),
+    0
+  );
   
   return (
     <div className={styles.container}>
@@ -316,6 +320,10 @@ export default function AttendanceRequestsPage() {
             {
               value: pendingRequestsCount,
               text: "בקשות ממתינות"
+            },
+            {
+              value: totalContainers,
+              text: "סה\"כ קונטיינרים"
             }
           ]}
           actions={[

--- a/src/containers/attendance-requests/filterRow.js
+++ b/src/containers/attendance-requests/filterRow.js
@@ -31,13 +31,15 @@ const getMonthOptions = () => {
 };
 
 
-// Helper to generate day options (1-31)
+// Helper to generate day options ("ALL" or 1-31)
 const getDayOptions = () => {
-  return Array.from({ length: 31 }, (_, i) => ({
-    value: i + 1,
-    label: String(i + 1),
-  }));
-
+  return [
+    { value: "ALL", label: "כל הימים" },
+    ...Array.from({ length: 31 }, (_, i) => ({
+      value: i + 1,
+      label: String(i + 1),
+    })),
+  ];
 };
 
 // Helper to generate year options (current year and 2 previous years)
@@ -139,7 +141,9 @@ export default function AttendanceRequestsFilter({
         },
 
     day: initialFilters?.day
-      ? { value: initialFilters.day, label: String(initialFilters.day) }
+      ? initialFilters.day === "ALL"
+        ? { value: "ALL", label: "כל הימים" }
+        : { value: initialFilters.day, label: String(initialFilters.day) }
       : { value: new Date().getDate(), label: String(new Date().getDate()) },
 
     workerId: initialFilters?.workerId || null,
@@ -248,7 +252,6 @@ export default function AttendanceRequestsFilter({
     const formattedFilters = {
       year: filters.year.value,
       month: filters.month.value,
-      day: filters.day.value,
       workerId: filters.workerId?.value,
       groupId: filters.groupId?.value,
       approvalStatus: "PENDING",


### PR DESCRIPTION
## Summary
- support selecting all days in pending attendance filters
- calculate total containers on pending attendance page

## Testing
- `pnpm lint` *(fails: Connect Timeout Error)*