### PR TITLE
Add SMS login info sending for managers

### DIFF
--- a/src/app/(backend)/actions/managers/getManagers.js
+++ b/src/app/(backend)/actions/managers/getManagers.js
@@ -50,6 +50,12 @@ const getManagers = async (filters = {}) => {
         email: true,
         phone: true,
         clientId: true,
+        userId: true,
+        user: {
+          select: {
+            username: true,
+          },
+        },
         createdAt: true,
         updatedAt: true,
       },

--- a/src/app/(backend)/actions/managers/sendManagerCredentialsSMS.js
+++ b/src/app/(backend)/actions/managers/sendManagerCredentialsSMS.js
@@ -1,0 +1,68 @@
+"use server";
+
+import prisma from "@/lib/prisma";
+import { z } from "zod";
+import sendSMS from "../sms/sendSMS";
+
+const schema = z.object({
+  managerId: z.string().min(1, "נדרש מזהה מנהל"),
+});
+
+const sendManagerCredentialsSMS = async (input) => {
+  try {
+    const parsed = schema.safeParse(input);
+    if (!parsed.success) {
+      return {
+        status: 400,
+        message: "הנתונים שהוזנו אינם תקינים",
+        errors: parsed.error.issues,
+      };
+    }
+
+    const { managerId } = parsed.data;
+
+    const manager = await prisma.manager.findUnique({
+      where: { id: managerId },
+      include: { user: true },
+    });
+
+    if (!manager || !manager.user) {
+      return { status: 404, message: "המנהל לא נמצא" };
+    }
+
+    const phone = manager.phone || manager.user.phone;
+
+    if (!phone) {
+      return { status: 400, message: "לא קיים מספר טלפון לשליחה" };
+    }
+
+    const BASE_URL =
+      process.env.NEXT_PUBLIC_APP_URL || "https://agriculture-hrms.vercel.app";
+    const loginUrl = `${BASE_URL}/login`;
+
+    const message = `שלום ${manager.name},\nפרטי הגישה שלך למערכת:\nשם משתמש: ${manager.user.username}\nסיסמה: 10203040 (אם לא שינית)\nקישור לכניסה: ${loginUrl}`;
+
+    const smsSent = await sendSMS(
+      phone,
+      message,
+      null,
+      manager.clientId,
+      manager.id,
+      manager.user.organizationId,
+      "ORGANIZATION",
+      "MANAGER"
+    );
+
+    if (smsSent) {
+      return { status: 200, message: "הפרטים נשלחו ב-SMS בהצלחה" };
+    }
+    return { status: 500, message: "שליחת ה-SMS נכשלה" };
+  } catch (error) {
+    console.error("Error sending manager credentials SMS:", error);
+    return { status: 500, message: "שגיאה בשליחת ה-SMS", error: error.message };
+  } finally {
+    await prisma.$disconnect();
+  }
+};
+
+export default sendManagerCredentialsSMS;

--- a/src/app/(backend)/actions/regionManagers/getRegionManagers.js
+++ b/src/app/(backend)/actions/regionManagers/getRegionManagers.js
@@ -50,6 +50,12 @@ const getRegionManagers = async (filters = {}) => {
         email: true,
         phone: true,
         clientId: true,
+        userId: true,
+        user: {
+          select: {
+            username: true,
+          },
+        },
         createdAt: true,
         updatedAt: true,
       },

--- a/src/app/(backend)/actions/regionManagers/sendRegionManagerCredentialsSMS.js
+++ b/src/app/(backend)/actions/regionManagers/sendRegionManagerCredentialsSMS.js
@@ -1,0 +1,68 @@
+"use server";
+
+import prisma from "@/lib/prisma";
+import { z } from "zod";
+import sendSMS from "../sms/sendSMS";
+
+const schema = z.object({
+  regionManagerId: z.string().min(1, "נדרש מזהה מנהל אזור"),
+});
+
+const sendRegionManagerCredentialsSMS = async (input) => {
+  try {
+    const parsed = schema.safeParse(input);
+    if (!parsed.success) {
+      return {
+        status: 400,
+        message: "הנתונים שהוזנו אינם תקינים",
+        errors: parsed.error.issues,
+      };
+    }
+
+    const { regionManagerId } = parsed.data;
+
+    const regionManager = await prisma.regionManager.findUnique({
+      where: { id: regionManagerId },
+      include: { user: true },
+    });
+
+    if (!regionManager || !regionManager.user) {
+      return { status: 404, message: "מנהל האזור לא נמצא" };
+    }
+
+    const phone = regionManager.phone || regionManager.user.phone;
+
+    if (!phone) {
+      return { status: 400, message: "לא קיים מספר טלפון לשליחה" };
+    }
+
+    const BASE_URL =
+      process.env.NEXT_PUBLIC_APP_URL || "https://agriculture-hrms.vercel.app";
+    const loginUrl = `${BASE_URL}/login`;
+
+    const message = `שלום ${regionManager.name},\nפרטי הגישה שלך למערכת:\nשם משתמש: ${regionManager.user.username}\nסיסמה: 10203040 (אם לא שינית)\nקישור לכניסה: ${loginUrl}`;
+
+    const smsSent = await sendSMS(
+      phone,
+      message,
+      null,
+      regionManager.clientId,
+      regionManager.id,
+      regionManager.user.organizationId,
+      "ORGANIZATION",
+      "MANAGER"
+    );
+
+    if (smsSent) {
+      return { status: 200, message: "הפרטים נשלחו ב-SMS בהצלחה" };
+    }
+    return { status: 500, message: "שליחת ה-SMS נכשלה" };
+  } catch (error) {
+    console.error("Error sending region manager credentials SMS:", error);
+    return { status: 500, message: "שגיאה בשליחת ה-SMS", error: error.message };
+  } finally {
+    await prisma.$disconnect();
+  }
+};
+
+export default sendRegionManagerCredentialsSMS;

--- a/src/components/credentialsSmsModal.js
+++ b/src/components/credentialsSmsModal.js
@@ -1,0 +1,39 @@
+"use client";
+
+import Modal from "./modal";
+import { FaSms } from "react-icons/fa";
+import Spinner from "@/components/spinner";
+import styles from "@/styles/components/credentialsSmsModal.module.scss";
+
+const CredentialsSmsModal = ({
+  isOpen,
+  onClose,
+  name,
+  username,
+  onSend,
+  loading,
+}) => {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="פרטי התחברות">
+      <div className={styles.container}>
+        <p className={styles.name}>{name}</p>
+        <div className={styles.field}>
+          <label>שם משתמש</label>
+          <input type="text" value={username || ""} readOnly />
+        </div>
+        <button className={styles.smsButton} onClick={onSend} disabled={loading}>
+          {loading ? (
+            <Spinner size={20} />
+          ) : (
+            <>
+              <FaSms style={{ marginLeft: "8px" }} />
+              שלח פרטים ב-SMS
+            </>
+          )}
+        </button>
+      </div>
+    </Modal>
+  );
+};
+
+export default CredentialsSmsModal;

--- a/src/styles/components/credentialsSmsModal.module.scss
+++ b/src/styles/components/credentialsSmsModal.module.scss
@@ -1,0 +1,43 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.name {
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+
+  input {
+    height: 40px;
+    padding: 0 12px;
+    border: 1px solid #e0e0e0;
+    border-radius: 6px;
+  }
+}
+
+.smsButton {
+  background-color: #4caf50;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 10px 20px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+
+  &:disabled {
+    background-color: #ccc;
+    cursor: not-allowed;
+  }
+}


### PR DESCRIPTION
## Summary
- allow sending credentials SMS to managers and region managers
- extend getManagers and getRegionManagers actions to include user info
- create server actions to send credentials SMS
- add credentials SMS modal component
- integrate into client managers tables

## Testing
- `npm run lint` *(fails: Cannot serialize key "parse" in parser)*